### PR TITLE
Simple changes to fix sshKeyAdd

### DIFF
--- a/lib/digitalocean.js
+++ b/lib/digitalocean.js
@@ -310,8 +310,8 @@ Digitalocean.prototype.sshKeyGet = function(id, callback) {
  * @param  {Function} callback [description]
  */
 Digitalocean.prototype.sshKeyAdd = function(name, pubKey, callback) {
-	this.get('ssh_keys/add/', {ssh_key_pub: pubKey}, function(error, body) {
-		callback(error, body.event_id);
+	this.get('ssh_keys/new/', {name: name, ssh_pub_key: pubKey}, function(error, body) {
+		callback(error, body.ssh_key);
 	});
 };
 /**
@@ -321,7 +321,7 @@ Digitalocean.prototype.sshKeyAdd = function(name, pubKey, callback) {
  * @param  {Function} callback [description]
  */
 Digitalocean.prototype.sshKeyEdit = function(id, pubKey, callback) {
-	this.get('ssh_keys/' + id + '/edit/', {ssh_key_pub: pubKey}, function(error, body) {
+	this.get('ssh_keys/' + id + '/edit/', {ssh_pub_key: pubKey}, function(error, body) {
 		callback(error, body.event_id);
 	});
 };


### PR DESCRIPTION
I had to make these adjustments to get `sshKeyAdd` to work as expected.

The callback now receives the following response on successful key creation:

```
{
  id: 9218,
  name: 'foo',
  ssh_pub_key: '..etc'
}
```
