### PR TITLE
Avoids uncatchable TypeErrors when API is not available.

### DIFF
--- a/lib/digitalocean.js
+++ b/lib/digitalocean.js
@@ -37,7 +37,7 @@ Digitalocean.prototype.get = function(url, parameters, callback) {
 				error = new Error(body.description);
 			}
 
-			callback(error, body);
+			callback(error, body || {});
 		}
 	);
 };


### PR DESCRIPTION
When HTTP requests fail, for example when network is down or
the API is not available the .get method passes undefined as body argument
to the callbacks. This results in a TypeError that can not be caught,
because its thrown in the callback of the HTTP request.

This fix proposes to pass {} as body instead. This way
callbacks on the API methods will receive the error from the get request
and get undefined as data argument.
