### PR TITLE
Update to error handling

### DIFF
--- a/lib/digitalocean.js
+++ b/lib/digitalocean.js
@@ -34,7 +34,7 @@ Digitalocean.prototype.get = function(url, parameters, callback) {
 		json: true
 	}, function(error, response, body) {
 			if(!error && !!body.status && body.status !== 'OK'){
-				error = new Error(body.description);
+				error = new Error(body.description || body.error_message);
 			}
 
 			callback(error, body || {});


### PR DESCRIPTION
The DO api now uses `error_message` to describe errors.
