### PR TITLE
Updated to latest API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 npm-debug.log
 node_modules
+test/config.js

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 npm-debug.log
 node_modules
-test/config.js

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ domainGet(id, callback)
 domainDestroy(id, callback)
 domainRecordGetAll(id, callback)
 domainRecordNew(id, recordType, data, name, priority, port, weight, callback)
+domainRecordGet(domain_id, record_id, callback)
 ```
 
 ### Events

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ sizeGetAll(callback)
 domainGetAll(callback)
 domainNew(name, ipAddress, callback)
 domainGet(id)
+domainDestroy(id)
 ```
 
 ### Events

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ dropletResize(id, sizeId, callback)
 dropletSnapshot(id, name, callback)
 dropletRestore(id, imageId, callback)
 dropletRebuild(id, imageId, callback)
+dropletRename(id, name, callback)
 dropletBackupEnable(id, callback)
 dropletBackupDisable(id, callback)
 dropletDestroy(id, callback)
@@ -68,6 +69,7 @@ imageGetGlobal(callback)
 imageGetMine(callback)
 imageGet(id, callback)
 imageDestroy(id, callback)
+imageTransfer(id, regionId, callback)
 ```
 
 ### SSH keys

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Convention for callback arguments: `callback(error, data)`
 dropletGetAll(callback)
 dropletNew(name, sizeId, imageId, regionId, sshKeyIds, privateNetworking, backupsEnabled, callback)
 dropletGet(id, callback)
-dropletRebootHard(id, callback)
+dropletReboot(id, callback)
 dropletPowerCycle(id, callback)
 dropletShutdown(id, callback)
 dropletPowerOff(id, callback)
@@ -51,8 +51,6 @@ dropletRestore(id, imageId, callback)
 dropletRebuild(id, imageId, callback)
 dropletRename(id, name, callback)
 dropletDestroy(id, callback)
-dropletBackupEnable(id, callback)
-dropletBackupDisable(id, callback)
 ```
 
 ### Regions

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ domainNew(name, ipAddress, callback)
 domainGet(id, callback)
 domainDestroy(id, callback)
 domainRecordGetAll(id, callback)
+domainRecordNew(id, recordType, data, name, priority, port, weight, callback)
 ```
 
 ### Events

--- a/README.md
+++ b/README.md
@@ -55,10 +55,10 @@ dropletBackupDisable(id, callback)
 dropletDestroy(id, callback)
 ```
 
-### Sizes
+### Regions
 
 ```js
-sizeGetAll(callback)
+regionGetAll(callback)
 ```
 
 ### Images
@@ -82,10 +82,18 @@ sshKeyEdit(id, pubKey, callback)
 sshKeyDestroy(id, callback)
 ```
 
-### Regions
+### Sizes
 
 ```js
-regionGetAll(callback)
+sizeGetAll(callback)
+```
+
+### Domains
+
+```js
+domainGetAll(callback)
+domainNew(name, ipAddress, callback)
+domainGet(id)
 ```
 
 ### Events

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ Convention for callback arguments: `callback(error, data)`
 
 ```js
 dropletGetAll(callback)
+dropletNew(name, sizeId, imageId, regionId, sshKeyIds, privateNetworking, backupsEnabled, callback)
 dropletGet(id, callback)
-dropletNew(name, sizeId, imageId, regionId, sshKeyIds, callback)
 dropletRebootHard(id, callback)
 dropletPowerCycle(id, callback)
 dropletShutdown(id, callback)
@@ -50,9 +50,9 @@ dropletSnapshot(id, name, callback)
 dropletRestore(id, imageId, callback)
 dropletRebuild(id, imageId, callback)
 dropletRename(id, name, callback)
+dropletDestroy(id, callback)
 dropletBackupEnable(id, callback)
 dropletBackupDisable(id, callback)
-dropletDestroy(id, callback)
 ```
 
 ### Regions
@@ -64,6 +64,7 @@ regionGetAll(callback)
 ### Images
 
 ```js
+images(filter, callback)
 imageGetAll(callback)
 imageGetGlobal(callback)
 imageGetMine(callback)
@@ -76,8 +77,8 @@ imageTransfer(id, regionId, callback)
 
 ```js
 sshKeyGetAll(callback)
-sshKeyGet(id, callback)
 sshKeyAdd(name, pubKey, callback)
+sshKeyGet(id, callback)
 sshKeyEdit(id, pubKey, callback)
 sshKeyDestroy(id, callback)
 ```
@@ -97,9 +98,9 @@ domainGet(id, callback)
 domainDestroy(id, callback)
 domainRecordGetAll(id, callback)
 domainRecordNew(id, recordType, data, name, priority, port, weight, callback)
-domainRecordGet(domain_id, record_id, callback)
-domainRecordEdit(domain_id, record_id, recordType, data, name, priority, port, weight, callback)
-domainRecordDestroy(domain_id, record_id, callback)
+domainRecordGet(id, recordId, callback)
+domainRecordEdit(id, recordId, recordType, data, name, priority, port, weight, callback)
+domainRecordDestroy(id, recordId, callback)
 ```
 
 ### Events

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ domainDestroy(id, callback)
 domainRecordGetAll(id, callback)
 domainRecordNew(id, recordType, data, name, priority, port, weight, callback)
 domainRecordGet(domain_id, record_id, callback)
+domainRecordEdit(domain_id, record_id, recordType, data, name, priority, port, weight, callback)
 ```
 
 ### Events

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ domainRecordGetAll(id, callback)
 domainRecordNew(id, recordType, data, name, priority, port, weight, callback)
 domainRecordGet(domain_id, record_id, callback)
 domainRecordEdit(domain_id, record_id, recordType, data, name, priority, port, weight, callback)
+domainRecordDestroy(domain_id, record_id, callback)
 ```
 
 ### Events

--- a/README.md
+++ b/README.md
@@ -93,8 +93,9 @@ sizeGetAll(callback)
 ```js
 domainGetAll(callback)
 domainNew(name, ipAddress, callback)
-domainGet(id)
-domainDestroy(id)
+domainGet(id, callback)
+domainDestroy(id, callback)
+domainRecordGetAll(id, callback)
 ```
 
 ### Events

--- a/lib/digitalocean.js
+++ b/lib/digitalocean.js
@@ -95,7 +95,7 @@ Digitalocean.prototype.dropletGet = function(id, callback) {
  * @param {[Number]}    id              Required, this is the id of your droplet that you want to reboot
  * @param {Function}    callback        [description]
  */
-Digitalocean.prototype.dropletRebootHard = function(id, callback) {
+Digitalocean.prototype.dropletReboot = function(id, callback) {
 	this.get('droplets/' + id + '/reboot/', {}, function(error, body) {
 		callback(error, body.event_id);
 	});
@@ -243,30 +243,6 @@ Digitalocean.prototype.dropletRename = function(id, name, callback) {
  */
 Digitalocean.prototype.dropletDestroy = function(id, callback) {
 	this.get('droplets/' + id + '/destroy/', {}, function(error, body) {
-		callback(error, body.event_id);
-	});
-};
-
-/**
- * Enable Automatic Backups
- * This method enables automatic backups which run in the background daily to backup your droplet's data.
- * @param {[Number]}    id              [description]
- * @param {Function}    callback        [description]
- */
-Digitalocean.prototype.dropletBackupEnable = function(id, callback) {
-	this.get('droplets/' + id + '/enable_backups/', {}, function(error, body) {
-		callback(error, body.event_id);
-	});
-};
-
-/**
- * Disable Automatic Backups
- * This method disables automatic backups from running to backup your droplet's data.
- * @param {[Number]}    id              [description]
- * @param {Function}    callback        [description]
- */
-Digitalocean.prototype.dropletBackupDisable = function(id, callback) {
-	this.get('droplets/' + id + '/disable_backups/', {}, function(error, body) {
 		callback(error, body.event_id);
 	});
 };

--- a/lib/digitalocean.js
+++ b/lib/digitalocean.js
@@ -424,7 +424,19 @@ Digitalocean.prototype.domainGet = function(id, callback) {
  */
 Digitalocean.prototype.domainDestroy = function(id, callback) {
 	this.get('domains/' + id + '/destroy/', {}, function(error, body) {
-		callback(error, body.domain);
+		callback(error, body.status);
+	});
+};
+
+/**
+ * All Domain Records
+ * This method returns all of your current domain records.
+ * @param  {[Number, String]}   id         Required, Integer or Domain Name (e.g. domain.com), specifies the domain to display.
+ * @param  {Function}           callback   [description]
+ */
+Digitalocean.prototype.domainRecordGetAll = function(id, callback) {
+	this.get('domains/' + id + '/records/', {}, function(error, body) {
+		callback(error, body.records);
 	});
 };
 

--- a/lib/digitalocean.js
+++ b/lib/digitalocean.js
@@ -417,6 +417,18 @@ Digitalocean.prototype.domainGet = function(id, callback) {
 };
 
 /**
+ * Destroy Domain
+ * This method deletes the specified domain.
+ * @param  {[Number, String]}   id         Required, Integer or Domain Name (e.g. domain.com), specifies the domain to display.
+ * @param  {Function}           callback   [description]
+ */
+Digitalocean.prototype.domainDestroy = function(id, callback) {
+	this.get('domains/' + id + '/destroy/', {}, function(error, body) {
+		callback(error, body.domain);
+	});
+};
+
+/**
 * Show event
 *	This method returns details of a event
 * @param  {[type]}   id       [description]

--- a/lib/digitalocean.js
+++ b/lib/digitalocean.js
@@ -52,6 +52,7 @@ Digitalocean.prototype.dropletGetAll = function(callback) {
 		callback(error, body.droplets);
 	});
 };
+
 /**
  * Show Droplet
  * This method returns full information for a specific droplet ID that is passed in the URL.
@@ -63,6 +64,7 @@ Digitalocean.prototype.dropletGet = function(id, callback) {
 		callback(error, body.droplet);
 	});
 };
+
 /**
  * New Droplet
  * This method allows you to create a new droplet. See the required parameters section below for an explanation of the variables that are needed to create a new droplet.
@@ -78,6 +80,7 @@ Digitalocean.prototype.dropletNew = function(name, sizeId, imageId, regionId, ss
 		callback(error, body.droplet);
 	});
 };
+
 /**
  * Reboot Droplet
  * This method allows you to reboot a droplet. This is the preferred method to use if a server is not responding.
@@ -374,6 +377,42 @@ Digitalocean.prototype.sshKeyDestroy = function(id, callback) {
 Digitalocean.prototype.sizeGetAll = function(callback) {
 	this.get('sizes/', {}, function(error, body) {
 		callback(error, body.sizes);
+	});
+};
+
+/**
+ * All Domains
+ * This method returns all of your current domains.
+ * @param  {Function} callback [description]
+ */
+Digitalocean.prototype.domainGetAll = function(callback) {
+	this.get('domains/', {}, function(error, body) {
+		callback(error, body.domains);
+	});
+};
+
+/**
+ * New Domain
+ * This method creates a new domain name with an A record for the specified [ip_address].
+ * @param  {[String]}   name      Required, name of the domain.
+ * @param  {[String]}   ipAddress Required, ip address for the domain's initial a record.
+ * @param  {Function}   callback  [description]
+ */
+Digitalocean.prototype.domainNew = function(name, ipAddress, callback) {
+	this.get('domains/new', {name: name, ip_address: ipAddress}, function(error, body) {
+		callback(error, body.domain);
+	});
+};
+
+/**
+ * Domain Show
+ * This method returns the specified domain.
+ * @param  {[Number, String]}   id         Required, Integer or Domain Name (e.g. domain.com), specifies the domain to display.
+ * @param  {Function}           callback   [description]
+ */
+Digitalocean.prototype.domainGet = function(id, callback) {
+	this.get('domains/' + id, {}, function(error, body) {
+		callback(error, body.domain);
 	});
 };
 

--- a/lib/digitalocean.js
+++ b/lib/digitalocean.js
@@ -459,6 +459,19 @@ Digitalocean.prototype.domainRecordNew = function(id, recordType, data, name, pr
 };
 
 /**
+ * Show Domain Record
+ * This method returns the specified domain record.
+ * @param  {[Number, String]}   domain_id  Required, Integer or Domain Name (e.g. domain.com), specifies the domain for which to retrieve a record.
+ * @param  {[Number]}           record_id  Required, Integer, specifies the record_id to retrieve.
+ * @param  {Function}           callback   [description]
+ */
+Digitalocean.prototype.domainRecordGet = function(domain_id, record_id, callback) {
+	this.get('domains/' + domain_id + '/records/' + record_id, {}, function(error, body) {
+		callback(error, body.record);
+	});
+};
+
+/**
 * Show event
 *	This method returns details of a event
 * @param  {[type]}   id       [description]

--- a/lib/digitalocean.js
+++ b/lib/digitalocean.js
@@ -181,6 +181,7 @@ Digitalocean.prototype.dropletRestore = function(id, imageId, callback) {
 		callback(error, body.event_id);
 	});
 };
+
 /**
  * Rebuild Droplet
  * This method allows you to reinstall a droplet with a default image. This is useful if you want to start again but retain the same IP address for your droplet.
@@ -193,6 +194,20 @@ Digitalocean.prototype.dropletRebuild = function(id, imageId, callback) {
 		callback(error, body.event_id);
 	});
 };
+
+/**
+ * Rename Droplet
+ * This method renames the droplet to the specified name.
+ * @param  {[type]}   id       [description]
+ * @param  {[type]}   name     [description]
+ * @param  {Function} callback [description]
+ */
+Digitalocean.prototype.dropletRename = function(id, name, callback) {
+	this.get('droplets/' + id + '/rename/', {name: name}, function(error, body) {
+		callback(error, body.event_id);
+	});
+};
+
 /**
  * Enable Automatic Backups
  * This method enables automatic backups which run in the background daily to backup your droplet's data.

--- a/lib/digitalocean.js
+++ b/lib/digitalocean.js
@@ -441,6 +441,24 @@ Digitalocean.prototype.domainRecordGetAll = function(id, callback) {
 };
 
 /**
+ * New Domain Record
+ * This method creates a new domain name with an A record for the specified [ip_address].
+ * @param  {[Number, String]}   id         Required, Integer or Domain Name (e.g. domain.com), specifies the domain to display.
+ * @param  {[String]}           recordType Required, String, the type of record you would like to create. 'A', 'CNAME', 'NS', 'TXT', 'MX' or 'SRV'
+ * @param  {[String]}           data       Required, String, this is the value of the record
+ * @param  {[String]}           name       Optional, String, Required for 'A', 'CNAME', 'TXT' and 'SRV' records
+ * @param  {[Number]}           priority   Optional, Integer, Required for 'SRV' and 'MX' records
+ * @param  {[Number]}           port       Optional, Integer, Required for 'SRV' records
+ * @param  {[Number]}           weight     Optional, Integer, Required for 'SRV' records
+ * @param  {Function}           callback   [description]
+ */
+Digitalocean.prototype.domainRecordNew = function(id, recordType, data, name, priority, port, weight, callback) {
+	this.get('domains/' + id + '/records/new', {record_type: recordType, data: data, name: name, priority: priority, port: port, weight: weight}, function(error, body) {
+		callback(error, body.domain_record);
+	});
+};
+
+/**
 * Show event
 *	This method returns details of a event
 * @param  {[type]}   id       [description]

--- a/lib/digitalocean.js
+++ b/lib/digitalocean.js
@@ -472,6 +472,25 @@ Digitalocean.prototype.domainRecordGet = function(domain_id, record_id, callback
 };
 
 /**
+ * Edit Domain Record
+ * This method creates a new domain name with an A record for the specified [ip_address].
+ * @param  {[Number, String]}   domain_id  Required, Integer or Domain Name (e.g. domain.com), specifies the domain to display.
+ * @param  {[Number]}           record_id  Required, Integer, specifies the record to update.
+ * @param  {[String]}           recordType Required, String, the type of record you would like to create. 'A', 'CNAME', 'NS', 'TXT', 'MX' or 'SRV'
+ * @param  {[String]}           data       Required, String, this is the value of the record
+ * @param  {[String]}           name       Optional, String, Required for 'A', 'CNAME', 'TXT' and 'SRV' records
+ * @param  {[Number]}           priority   Optional, Integer, Required for 'SRV' and 'MX' records
+ * @param  {[Number]}           port       Optional, Integer, Required for 'SRV' records
+ * @param  {[Number]}           weight     Optional, Integer, Required for 'SRV' records
+ * @param  {Function}           callback   [description]
+ */
+Digitalocean.prototype.domainRecordNew = function(domain_id, record_id, recordType, data, name, priority, port, weight, callback) {
+	this.get('domains/' + domain_id + '/records/' + record_id + '/edit', {record_type: recordType, data: data, name: name, priority: priority, port: port, weight: weight}, function(error, body) {
+		callback(error, body.domain_record);
+	});
+};
+
+/**
 * Show event
 *	This method returns details of a event
 * @param  {[type]}   id       [description]

--- a/lib/digitalocean.js
+++ b/lib/digitalocean.js
@@ -6,13 +6,13 @@ var API_URL = 'https://api.digitalocean.com';
 
 /**
  * Digitalocean API Client
- * @param {[type]} clientID [description]
- * @param {[type]} apiKey   [description]
+ * @param {[String]}    clientID        Your account's DigitalOcean Client Id
+ * @param {[String]}    apiKey          Your account's DigitalOcean API Key
  */
 var Digitalocean = function(clientID, apiKey) {
 	this.credentials = {
-			client_id: clientID,
-			api_key: apiKey
+                client_id:      clientID,
+                api_key:        apiKey
 	};
 };
 module.exports = Digitalocean;
@@ -20,32 +20,30 @@ module.exports = Digitalocean;
 /**
  * Helper to handle requests to the API with authorization
  *
- * @param  {[String]}   url        address part after API root
- * @param  {[Object]}   parameters additional parameters
- * @param  {Function} callback   [description]
+ * @param {[String]}    url             address part after API root
+ * @param {[Object]}    parameters      additional parameters
+ * @param {Function}    callback        [description]
  */
 Digitalocean.prototype.get = function(url, parameters, callback) {
 	extend(parameters, this.credentials); // Add credentials to parameters
 	var getURL = API_URL + '/' + url + '?' + querystring.stringify(parameters); // Construct URL with parameters
 
 	request.get({
-		url: getURL,
-		strictSSL: true,
-		json: true
+		url:            getURL,
+		strictSSL:      true,
+		json:           true
 	}, function(error, response, body) {
-			if(!error && !!body.status && body.status !== 'OK'){
-				error = new Error(body.description || body.error_message);
-			}
-
-			callback(error, body || {});
-		}
-	);
+                if(!error && !!body.status && body.status !== 'OK') {
+                        error = new Error(body.description || body.error_message);
+                }
+                callback(error, body || {});
+	});
 };
 
 /**
  * Show All Active Droplets
  * This method returns all active droplets that are currently running in your account. All available API information is presented for each droplet.
- * @param  {Function} callback [description]
+ * @param  {Function}   callback        [description]
  */
 Digitalocean.prototype.dropletGetAll = function(callback) {
 	this.get('droplets/', {}, function(error, body) {
@@ -54,10 +52,36 @@ Digitalocean.prototype.dropletGetAll = function(callback) {
 };
 
 /**
+ * New Droplet
+ * This method allows you to create a new droplet. See the required parameters section below for an explanation of the variables that are needed to create a new droplet.
+ * @param {[String]}    name            Required, this is the name of the droplet - must be formatted by hostname rules
+ * @param {[Number]}    sizeId          Required, this is the id of the size you would like the droplet created at
+ * @param {[Number]}    imageId         Required, this is the id of the image you would like the droplet created with
+ * @param {[Number]}    regionId        Required, this is the id of the region you would like your server in IE: US/Amsterdam
+ * @param {[Array]}     sshKeyIds       Optional, list of ssh_key_ids that you would like to be added to the server
+ * @param {[Boolean]}   privateNetworking Optional, enables a private network interface if the region supports private networking
+ * @param {[Boolean]}   backupsEnabled  Optional, enables a private network interface if the region supports private networking
+ * @param {Function}    callback        [description]
+ */
+Digitalocean.prototype.dropletNew = function(name, sizeId, imageId, regionId, sshKeyIds, privateNetworking, backupsEnabled, callback) {
+	this.get('droplets/new',{
+                name: name,
+                size_id:            sizeId,
+                image_id:           imageId,
+                region_id:          regionId,
+                ssh_key_ids:        sshKeyIds,
+                private_networking: privateNetworking,
+                backups_enabled:    backupsEnabled
+        }, function(error, body) {
+		callback(error, body.droplet);
+	});
+};
+
+/**
  * Show Droplet
  * This method returns full information for a specific droplet ID that is passed in the URL.
- * @param  {[Number]}   id [description]
- * @param  {Function} callback  [description]
+ * @param {[Number]}    id              Required, this is the id of your droplet
+ * @param {Function}    callback        [description]
  */
 Digitalocean.prototype.dropletGet = function(id, callback) {
 	this.get('droplets/' + id, {}, function(error, body) {
@@ -66,121 +90,117 @@ Digitalocean.prototype.dropletGet = function(id, callback) {
 };
 
 /**
- * New Droplet
- * This method allows you to create a new droplet. See the required parameters section below for an explanation of the variables that are needed to create a new droplet.
- * @param  {[String]}   name     Required, this is the name of the droplet - must be formatted by hostname rules
- * @param  {[Number]}   sizeId   Required, this is the id of the size you would like the droplet created at
- * @param  {[Number]}   imageId  Required, this is the id of the image you would like the droplet created with
- * @param  {[Number]}   regionId Required, this is the id of the region you would like your server in IE: US/Amsterdam
- * @param  {[Array]}   sshKeyIds Optional, list of ssh_key_ids that you would like to be added to the server
- * @param  {Function} callback [description]
- */
-Digitalocean.prototype.dropletNew = function(name, sizeId, imageId, regionId, sshKeyIds, callback) {
-	this.get('droplets/new', {name: name, size_id: sizeId, image_id: imageId, region_id: regionId, ssh_key_ids: sshKeyIds}, function(error, body) {
-		callback(error, body.droplet);
-	});
-};
-
-/**
  * Reboot Droplet
  * This method allows you to reboot a droplet. This is the preferred method to use if a server is not responding.
- * @param  {[type]}   id       [description]
- * @param  {Function} callback [description]
+ * @param {[Number]}    id              Required, this is the id of your droplet that you want to reboot
+ * @param {Function}    callback        [description]
  */
 Digitalocean.prototype.dropletRebootHard = function(id, callback) {
 	this.get('droplets/' + id + '/reboot/', {}, function(error, body) {
 		callback(error, body.event_id);
 	});
 };
+
 /**
  * Power Cycle Droplet
  * This method allows you to power cycle a droplet. This will turn off the droplet and then turn it back on.
- * @param  {[type]}   id       [description]
- * @param  {Function} callback [description]
+ * @param {[Number]}    id              Required, this is the id of your droplet that you want to power cycle
+ * @param {Function}    callback        [description]
  */
 Digitalocean.prototype.dropletPowerCycle = function(id, callback) {
 	this.get('droplets/' + id + '/power_cycle/', {}, function(error, body) {
 		callback(error, body.event_id);
 	});
 };
+
 /**
  * Shut Down Droplet
  * This method allows you to shutdown a running droplet. The droplet will remain in your account.
- * @param  {[type]}   id       [description]
- * @param  {Function} callback [description]
+ * @param {[Number]}    id              Required, this is the id of your droplet that you want to shutdown
+ * @param {Function}    callback        [description]
  */
 Digitalocean.prototype.dropletShutdown = function(id, callback) {
 	this.get('droplets/' + id + '/shutdown/', {}, function(error, body) {
 		callback(error, body.event_id);
 	});
 };
+
 /**
  * Power Off
  * This method allows you to poweroff a running droplet. The droplet will remain in your account.
- * @param  {[type]}   id       [description]
- * @param  {Function} callback [description]
+ * @param {[Number]}    id              Required, this is the id of your droplet that you want to power off
+ * @param {Function}    callback        [description]
  */
 Digitalocean.prototype.dropletPowerOff = function(id, callback) {
 	this.get('droplets/' + id + '/power_off/', {}, function(error, body) {
 		callback(error, body.event_id);
 	});
 };
+
 /**
  * Power On
  * This method allows you to poweron a powered off droplet.
- * @param  {[type]}   id       [description]
- * @param  {Function} callback [description]
+ * @param {[Number]}    id              Required, this is the id of your droplet that you want to power on
+ * @param {Function}    callback        [description]
  */
 Digitalocean.prototype.dropletPowerOn = function(id, callback) {
 	this.get('droplets/' + id + '/power_on/', {}, function(error, body) {
 		callback(error, body.event_id);
 	});
 };
+
 /**
  * Reset Root Password
  * This method will reset the root password for a droplet. Please be aware that this will reboot the droplet to allow resetting the password.
- * @param  {[type]}   id       [description]
- * @param  {Function} callback [description]
+ * @param {[Number]}    id              Required, this is the id of your droplet that you want to reset password on
+ * @param {Function}    callback        [description]
  */
-Digitalocean.prototype.dropletResetRootPassword = function(id, callback) {
-	this.get('droplets/' + id + '/password_reset/', {}, function(error, body) {
+Digitalocean.prototype.dropletResetRootPassword = function(id , callback) {
+	this.get('droplets/' + id  + '/password_reset/', {}, function(error, body) {
 		callback(error, body.event_id);
 	});
 };
+
 /**
  * Resize Droplet
  * This method allows you to resize a specific droplet to a different size. This will affect the number of processors and memory allocated to the droplet.
- * @param  {[type]}   id       [description]
- * @param  {[type]}   sizeId       [description]
- * @param  {Function} callback [description]
+ * @param {[Number]}    id              Required, this is the id of your droplet that you want to resize
+ * @param {[Number]}    sizeId          Required, this is the id of the size you would like the droplet to be resized to
+ * @param {Function}    callback        [description]
  */
 Digitalocean.prototype.dropletResize = function(id, sizeId, callback) {
-	this.get('droplets/' + id + '/resize/', {size_id: sizeId}, function(error, body) {
+	this.get('droplets/' + id + '/resize/', {
+                size_id:        sizeId
+        }, function(error, body) {
 		callback(error, body.event_id);
 	});
 };
 /**
  * Take a Snapshot
  * This method allows you to take a snapshot of the running droplet, which can later be restored or used to create a new droplet from the same image. Please be aware this may cause a reboot.
- * @param  {[type]}   id       [description]
- * @param  {[type]}   name     [description]
- * @param  {Function} callback [description]
+ * @param {[Number]}    id              Required, this is the id of your droplet that you want to resize
+ * @param {[String]}    name            Optional, this is the name of the new snapshot you want to create. If not set, the snapshot name will default to date/time
+ * @param {Function}    callback        [description]
  */
 Digitalocean.prototype.dropletSnapshot = function(id, name, callback) {
-	this.get('droplets/' + id + '/snapshot/', {name: name}, function(error, body) {
+	this.get('droplets/' + id + '/snapshot/', {
+                name:           name
+        }, function(error, body) {
 		callback(error, body.event_id);
 	});
 };
 
 /**
  * Restore Droplet
- *This method allows you to restore a droplet with a previous image or snapshot. This will be a mirror copy of the image or snapshot to your droplet. Be sure you have backed up any necessary information prior to restore.
- * @param  {[type]}   id       [description]
- * @param  {[type]}   imageId  [description]
- * @param  {Function} callback [description]
+ * This method allows you to restore a droplet with a previous image or snapshot. This will be a mirror copy of the image or snapshot to your droplet. Be sure you have backed up any necessary information prior to restore.
+ * @param {[Number]}    id              Required, this is the id of your droplet that you want to restore
+ * @param {[Number]}    imageId         Required, this is the id of the image you would like to use to restore your droplet with
+ * @param {Function}    callback        [description]
  */
 Digitalocean.prototype.dropletRestore = function(id, imageId, callback) {
-	this.get('droplets/' + id + '/restore/', {image_id: imageId}, function(error, body) {
+	this.get('droplets/' + id + '/restore/', {
+                image_id:       imageId
+        }, function(error, body) {
 		callback(error, body.event_id);
 	});
 };
@@ -188,12 +208,14 @@ Digitalocean.prototype.dropletRestore = function(id, imageId, callback) {
 /**
  * Rebuild Droplet
  * This method allows you to reinstall a droplet with a default image. This is useful if you want to start again but retain the same IP address for your droplet.
- * @param  {[type]}   id       [description]
- * @param  {[type]}   imageId  [description]
- * @param  {Function} callback [description]
+ * @param {[Number]}    id              Required, this is the id of your droplet that you want to rebuild
+ * @param {[Number]}    imageId         Required, this is the id of the image you would like to use to rebuild your droplet with
+ * @param {Function}    callback        [description]
  */
 Digitalocean.prototype.dropletRebuild = function(id, imageId, callback) {
-	this.get('droplets/' + id + '/rebuild/', {image_id: imageId}, function(error, body) {
+	this.get('droplets/' + id + '/rebuild/', {
+                image_id:       imageId
+        }, function(error, body) {
 		callback(error, body.event_id);
 	});
 };
@@ -201,43 +223,23 @@ Digitalocean.prototype.dropletRebuild = function(id, imageId, callback) {
 /**
  * Rename Droplet
  * This method renames the droplet to the specified name.
- * @param  {[type]}   id       [description]
- * @param  {[type]}   name     [description]
- * @param  {Function} callback [description]
+ * @param {[Number]}    id               Required, this is the id of your droplet that you want to rename
+ * @param {[String]}    name            Required, new name of the droplet
+ * @param {Function}    callback        [description]
  */
 Digitalocean.prototype.dropletRename = function(id, name, callback) {
-	this.get('droplets/' + id + '/rename/', {name: name}, function(error, body) {
+	this.get('droplets/' + id + '/rename/', {
+                name:           name
+        }, function(error, body) {
 		callback(error, body.event_id);
 	});
 };
 
 /**
- * Enable Automatic Backups
- * This method enables automatic backups which run in the background daily to backup your droplet's data.
- * @param  {[type]}   id       [description]
- * @param  {Function} callback [description]
- */
-Digitalocean.prototype.dropletBackupEnable = function(id, callback) {
-	this.get('droplets/' + id + '/enable_backups/', {}, function(error, body) {
-		callback(error, body.event_id);
-	});
-};
-/**
- * Disable Automatic Backups
- * This method disables automatic backups from running to backup your droplet's data.
- * @param  {[type]}   id       [description]
- * @param  {Function} callback [description]
- */
-Digitalocean.prototype.dropletBackupDisable = function(id, callback) {
-	this.get('droplets/' + id + '/disable_backups/', {}, function(error, body) {
-		callback(error, body.event_id);
-	});
-};
-/**
  * Destroy Droplet
  * This method destroys one of your droplets - this is irreversible.
- * @param  {[type]}   id       [description]
- * @param  {Function} callback [description]
+ * @param {[Number]}    id              Required, this is the id of the droplet you want to destroy
+ * @param {Function}    callback        [description]
  */
 Digitalocean.prototype.dropletDestroy = function(id, callback) {
 	this.get('droplets/' + id + '/destroy/', {}, function(error, body) {
@@ -246,9 +248,33 @@ Digitalocean.prototype.dropletDestroy = function(id, callback) {
 };
 
 /**
+ * Enable Automatic Backups
+ * This method enables automatic backups which run in the background daily to backup your droplet's data.
+ * @param {[Number]}    id              [description]
+ * @param {Function}    callback        [description]
+ */
+Digitalocean.prototype.dropletBackupEnable = function(id, callback) {
+	this.get('droplets/' + id + '/enable_backups/', {}, function(error, body) {
+		callback(error, body.event_id);
+	});
+};
+
+/**
+ * Disable Automatic Backups
+ * This method disables automatic backups from running to backup your droplet's data.
+ * @param {[Number]}    id              [description]
+ * @param {Function}    callback        [description]
+ */
+Digitalocean.prototype.dropletBackupDisable = function(id, callback) {
+	this.get('droplets/' + id + '/disable_backups/', {}, function(error, body) {
+		callback(error, body.event_id);
+	});
+};
+
+/**
  * All Regions
  * This method will return all the available regions within the Digital Ocean cloud.
- * @param  {Function} callback [description]
+ * @param {Function}    callback        [description]
  */
 Digitalocean.prototype.regionGetAll = function(callback) {
 	this.get('regions/', {}, function(error, body) {
@@ -259,29 +285,34 @@ Digitalocean.prototype.regionGetAll = function(callback) {
 /**
  * All Images
  * This method returns all the available images that can be accessed by your client ID. You will have access to all public images by default, and any snapshots or backups that you have created in your own account.
- * @param  {Function} callback [description]
+ * @param {[String]}    filter          Optional, either "my_images" or "global" 
+ * @param {Function}    callback        [description]
  */
+Digitalocean.prototype.images = function(filter, callback) {
+	this.get('images/', {
+                filter:         filter
+        }, function(error, body) {
+		callback(error, body.images);
+	});
+};
+
 Digitalocean.prototype.imageGetAll = function(callback) {
-	this.get('images/', {}, function(error, body) {
-		callback(error, body.images);
-	});
+        this.images(null, callback);
 };
+
 Digitalocean.prototype.imageGetGlobal = function(callback) {
-	this.get('images/', {filter: 'global'}, function(error, body) {
-		callback(error, body.images);
-	});
+        this.images('global', callback);
 };
+
 Digitalocean.prototype.imageGetMine = function(callback) {
-	this.get('images/', {filter: 'my_images'}, function(error, body) {
-		callback(error, body.images);
-	});
+        this.images('my_images', callback);
 };
 
 /**
  * Show Image
  * This method displays the attributes of an image.
- * @param  {[type]}   id       [description]
- * @param  {Function} callback [description]
+ * @param {[Number]}    id              Required, this is the id of the image you would like to use to rebuild your droplet with
+ * @param {Function}    callback        [description]
  */
 Digitalocean.prototype.imageGet = function(id, callback) {
 	this.get('images/' + id + '/', {}, function(error, body) {
@@ -292,24 +323,26 @@ Digitalocean.prototype.imageGet = function(id, callback) {
 /**
  * Destroy Image
  * This method allows you to destroy an image. There is no way to restore a deleted image so be careful and ensure your data is properly backed up.
- * @param  {[type]}   id       [description]
- * @param  {Function} callback [description]
+ * @param {[Number]}    id              Required, this is the id of the image you would like to destroy
+ * @param {Function}    callback        [description]
  */
 Digitalocean.prototype.imageDestroy = function(id, callback) {
 	this.get('images/' + id + '/destroy/', {}, function(error, body) {
-		callback(error, body.event_id);
+		callback(error, body.status);
 	});
 };
 
 /**
  * Transfer Image
  * This method allows you to transfer an image to a specified region.
- * @param  {[type]}   id       [description]
- * @param  {[type]}   regionId [description]
- * @param  {Function} callback [description]
+ * @param {[Number]}    id              Required, this is the id of the image you would like to transfer.
+ * @param {[Number]}    regionId        Required, this is the id of the region to which you would like to transfer.
+ * @param {Function}    callback        [description]
  */
 Digitalocean.prototype.imageTransfer = function(id, regionId, callback) {
-	this.get('images/' + id + '/transfer/', {region_id : regionId}, function(error, body) {
+	this.get('images/' + id + '/transfer/', {
+                region_id:      regionId
+        }, function(error, body) {
 		callback(error, body.event_id);
 	});
 };
@@ -317,51 +350,62 @@ Digitalocean.prototype.imageTransfer = function(id, regionId, callback) {
 /**
  * All SSH Keys
  * This method lists all the available public SSH keys in your account that can be added to a droplet.
- * @param  {Function} callback [description]
+ * @param {Function}    callback        [description]
  */
 Digitalocean.prototype.sshKeyGetAll = function(callback) {
 	this.get('ssh_keys/', {}, function(error, body) {
 		callback(error, body.ssh_keys);
 	});
 };
+
+/**
+ * Add SSH Key
+ * This method allows you to add a new public SSH key to your account.
+ * @param {[String]}    name            Required, the name you want to give this SSH key.
+ * @param {[String]}    pubKey          Required, the actual public SSH key.
+ * @param {Function}    callback        [description]
+ */
+Digitalocean.prototype.sshKeyAdd = function(name, pubKey, callback) {
+	this.get('ssh_keys/new/', {
+                name:           name,
+                ssh_pub_key:    pubKey
+        }, function(error, body) {
+		callback(error, body.ssh_key);
+	});
+};
+
 /**
  * Show SSH Key
  * This method shows a specific public SSH key in your account that can be added to a droplet.
- * @param  {[type]}   id       [description]
- * @param  {Function} callback [description]
+ * @param {[Number]}    id              Required, this is the id of the ssh key you would like to get information on.
+ * @param {Function}    callback        [description]
  */
 Digitalocean.prototype.sshKeyGet = function(id, callback) {
 	this.get('ssh_keys/' + id + '/', {}, function(error, body) {
 		callback(error, body.ssh_key);
 	});
 };
-/**
- * Add SSH Key
- * This method allows you to add a new public SSH key to your account.
- * @param  {[type]}   id       [description]
- * @param  {Function} callback [description]
- */
-Digitalocean.prototype.sshKeyAdd = function(name, pubKey, callback) {
-	this.get('ssh_keys/new/', {name: name, ssh_pub_key: pubKey}, function(error, body) {
-		callback(error, body.ssh_key);
-	});
-};
+
 /**
  * Edit SSH Key
  * This method allows you to modify an existing public SSH key in your account.
- * @param  {[type]}   id       [description]
- * @param  {Function} callback [description]
+ * @param {[type]}      id              Required, this is the id of the ssh key you would like to edit.
+ * @param {[String]}    pubKey          Required, the public SSH key.
+ * @param {Function}    callback        [description]
  */
 Digitalocean.prototype.sshKeyEdit = function(id, pubKey, callback) {
-	this.get('ssh_keys/' + id + '/edit/', {ssh_pub_key: pubKey}, function(error, body) {
+	this.get('ssh_keys/' + id + '/edit/', {
+                ssh_pub_key:    pubKey
+        }, function(error, body) {
 		callback(error, body.event_id);
 	});
 };
+
 /**
  * Destroy SSH Key
  * This method will delete the SSH key from your account.
- * @param  {[type]}   id       [description]
- * @param  {Function} callback [description]
+ * @param {[Number]}    id              Required, this is the id of the ssh key you would like to destroy.
+ * @param {Function}    callback        [description]
  */
 Digitalocean.prototype.sshKeyDestroy = function(id, callback) {
 	this.get('ssh_keys/' + id + '/destroy/', {}, function(error, body) {
@@ -372,7 +416,7 @@ Digitalocean.prototype.sshKeyDestroy = function(id, callback) {
 /**
  * All Sizes
  * This method returns all the available sizes that can be used to create a droplet.
- * @param  {Function} callback [description]
+ * @param {Function}    callback        [description]
  */
 Digitalocean.prototype.sizeGetAll = function(callback) {
 	this.get('sizes/', {}, function(error, body) {
@@ -383,7 +427,7 @@ Digitalocean.prototype.sizeGetAll = function(callback) {
 /**
  * All Domains
  * This method returns all of your current domains.
- * @param  {Function} callback [description]
+ * @param {Function}    callback        [description]
  */
 Digitalocean.prototype.domainGetAll = function(callback) {
 	this.get('domains/', {}, function(error, body) {
@@ -394,12 +438,15 @@ Digitalocean.prototype.domainGetAll = function(callback) {
 /**
  * New Domain
  * This method creates a new domain name with an A record for the specified [ip_address].
- * @param  {[String]}   name      Required, name of the domain.
- * @param  {[String]}   ipAddress Required, ip address for the domain's initial a record.
- * @param  {Function}   callback  [description]
+ * @param {[String]}    name            Required, name of the domain.
+ * @param {[String]}    ipAddress       Required, ip address for the domain's initial a record.
+ * @param {Function}    callback        [description]
  */
 Digitalocean.prototype.domainNew = function(name, ipAddress, callback) {
-	this.get('domains/new', {name: name, ip_address: ipAddress}, function(error, body) {
+	this.get('domains/new', {
+                name:           name,
+                ip_address:     ipAddress
+        }, function(error, body) {
 		callback(error, body.domain);
 	});
 };
@@ -407,8 +454,8 @@ Digitalocean.prototype.domainNew = function(name, ipAddress, callback) {
 /**
  * Domain Show
  * This method returns the specified domain.
- * @param  {[Number, String]}   id         Required, Integer or Domain Name (e.g. domain.com), specifies the domain to display.
- * @param  {Function}           callback   [description]
+ * @param {[Number, String]} id         Required, Integer or Domain Name (e.g. domain.com), specifies the domain to display.
+ * @param {Function}         callback   [description]
  */
 Digitalocean.prototype.domainGet = function(id, callback) {
 	this.get('domains/' + id, {}, function(error, body) {
@@ -419,8 +466,8 @@ Digitalocean.prototype.domainGet = function(id, callback) {
 /**
  * Destroy Domain
  * This method deletes the specified domain.
- * @param  {[Number, String]}   id         Required, Integer or Domain Name (e.g. domain.com), specifies the domain to display.
- * @param  {Function}           callback   [description]
+ * @param {[Number, String]} id         Required, Integer or Domain Name (e.g. domain.com), specifies the domain to display.
+ * @param {Function}         callback   [description]
  */
 Digitalocean.prototype.domainDestroy = function(id, callback) {
 	this.get('domains/' + id + '/destroy/', {}, function(error, body) {
@@ -431,8 +478,8 @@ Digitalocean.prototype.domainDestroy = function(id, callback) {
 /**
  * All Domain Records
  * This method returns all of your current domain records.
- * @param  {[Number, String]}   id         Required, Integer or Domain Name (e.g. domain.com), specifies the domain to display.
- * @param  {Function}           callback   [description]
+ * @param {[Number, String]} id         Required, Integer or Domain Name (e.g. domain.com), specifies the domain to display.
+ * @param {Function}         callback   [description]
  */
 Digitalocean.prototype.domainRecordGetAll = function(id, callback) {
 	this.get('domains/' + id + '/records/', {}, function(error, body) {
@@ -443,17 +490,24 @@ Digitalocean.prototype.domainRecordGetAll = function(id, callback) {
 /**
  * New Domain Record
  * This method creates a new domain name with an A record for the specified [ip_address].
- * @param  {[Number, String]}   id         Required, Integer or Domain Name (e.g. domain.com), specifies the domain to display.
- * @param  {[String]}           recordType Required, String, the type of record you would like to create. 'A', 'CNAME', 'NS', 'TXT', 'MX' or 'SRV'
- * @param  {[String]}           data       Required, String, this is the value of the record
- * @param  {[String]}           name       Optional, String, Required for 'A', 'CNAME', 'TXT' and 'SRV' records
- * @param  {[Number]}           priority   Optional, Integer, Required for 'SRV' and 'MX' records
- * @param  {[Number]}           port       Optional, Integer, Required for 'SRV' records
- * @param  {[Number]}           weight     Optional, Integer, Required for 'SRV' records
- * @param  {Function}           callback   [description]
+ * @param {[Number, String]} id         Required, Integer or Domain Name (e.g. domain.com), specifies the domain to display.
+ * @param {[String]}         recordType Required, the type of record you would like to create. 'A', 'CNAME', 'NS', 'TXT', 'MX' or 'SRV'
+ * @param {[String]}         data       Required, this is the value of the record
+ * @param {[String]}         name       Optional, Required for 'A', 'CNAME', 'TXT' and 'SRV' records
+ * @param {[Number]}         priority   Optional, Required for 'SRV' and 'MX' records
+ * @param {[Number]}         port       Optional, Required for 'SRV' records
+ * @param {[Number]}         weight     Optional, Required for 'SRV' records
+ * @param {Function}         callback   [description]
  */
 Digitalocean.prototype.domainRecordNew = function(id, recordType, data, name, priority, port, weight, callback) {
-	this.get('domains/' + id + '/records/new', {record_type: recordType, data: data, name: name, priority: priority, port: port, weight: weight}, function(error, body) {
+	this.get('domains/' + id + '/records/new', {
+                record_type:    recordType,
+                data:           data,
+                name:           name,
+                priority:       priority,
+                port:           port,
+                weight:         weight
+        }, function(error, body) {
 		callback(error, body.domain_record);
 	});
 };
@@ -461,12 +515,12 @@ Digitalocean.prototype.domainRecordNew = function(id, recordType, data, name, pr
 /**
  * Show Domain Record
  * This method returns the specified domain record.
- * @param  {[Number, String]}   domain_id  Required, Integer or Domain Name (e.g. domain.com), specifies the domain for which to retrieve a record.
- * @param  {[Number]}           record_id  Required, Integer, specifies the record_id to retrieve.
- * @param  {Function}           callback   [description]
+ * @param {[Number, String]} id         Required, Integer or Domain Name (e.g. domain.com), specifies the domain for which to retrieve a record.
+ * @param {[Number]}         recordId   Required, specifies the record_id to retrieve.
+ * @param {Function}         callback   [description]
  */
-Digitalocean.prototype.domainRecordGet = function(domain_id, record_id, callback) {
-	this.get('domains/' + domain_id + '/records/' + record_id, {}, function(error, body) {
+Digitalocean.prototype.domainRecordGet = function(id, recordId, callback) {
+	this.get('domains/' + id + '/records/' + recordId, {}, function(error, body) {
 		callback(error, body.record);
 	});
 };
@@ -474,18 +528,25 @@ Digitalocean.prototype.domainRecordGet = function(domain_id, record_id, callback
 /**
  * Edit Domain Record
  * This method edits an existing domain record.
- * @param  {[Number, String]}   domain_id  Required, Integer or Domain Name (e.g. domain.com), specifies the domain to display.
- * @param  {[Number]}           record_id  Required, Integer, specifies the record to update.
- * @param  {[String]}           recordType Required, String, the type of record you would like to create. 'A', 'CNAME', 'NS', 'TXT', 'MX' or 'SRV'
- * @param  {[String]}           data       Required, String, this is the value of the record
- * @param  {[String]}           name       Optional, String, Required for 'A', 'CNAME', 'TXT' and 'SRV' records
- * @param  {[Number]}           priority   Optional, Integer, Required for 'SRV' and 'MX' records
- * @param  {[Number]}           port       Optional, Integer, Required for 'SRV' records
- * @param  {[Number]}           weight     Optional, Integer, Required for 'SRV' records
- * @param  {Function}           callback   [description]
+ * @param {[Number, String]} id         Required, Integer or Domain Name (e.g. domain.com), specifies the domain to display.
+ * @param {[Number]}         recordId   Required, specifies the record to update.
+ * @param {[String]}         recordType Required, the type of record you would like to create. 'A', 'CNAME', 'NS', 'TXT', 'MX' or 'SRV'
+ * @param {[String]}         data       Required, this is the value of the record
+ * @param {[String]}         name       Optional, Required for 'A', 'CNAME', 'TXT' and 'SRV' records
+ * @param {[Number]}         priority   Optional, Required for 'SRV' and 'MX' records
+ * @param {[Number]}         port       Optional, Required for 'SRV' records
+ * @param {[Number]}         weight     Optional, Required for 'SRV' records
+ * @param {Function}         callback   [description]
  */
-Digitalocean.prototype.domainRecordEdit = function(domain_id, record_id, recordType, data, name, priority, port, weight, callback) {
-	this.get('domains/' + domain_id + '/records/' + record_id + '/edit', {record_type: recordType, data: data, name: name, priority: priority, port: port, weight: weight}, function(error, body) {
+Digitalocean.prototype.domainRecordEdit = function(id, recordId, recordType, data, name, priority, port, weight, callback) {
+	this.get('domains/' + id + '/records/' + recordId + '/edit', {
+                record_type:    recordType,
+                data:           data,
+                name:           name,
+                priority:       priority,
+                port:           port,
+                weight:         weight
+        }, function(error, body) {
 		callback(error, body.domain_record);
 	});
 };
@@ -493,24 +554,24 @@ Digitalocean.prototype.domainRecordEdit = function(domain_id, record_id, recordT
 /**
  * Destroy Domain Record
  * This method deletes the specified domain record.
- * @param  {[Number, String]}   domain_id  Required, Integer or Domain Name (e.g. domain.com), specifies the domain for which to destroy a record.
- * @param  {[Number]}           record_id  Required, Integer, specifies which record to destroy.
- * @param  {Function}           callback   [description]
+ * @param {[Number, String]} id         Required, Integer or Domain Name (e.g. domain.com), specifies the domain for which to destroy a record.
+ * @param {[Number]}         recordId   Required, specifies which record to destroy.
+ * @param {Function}         callback   [description]
  */
-Digitalocean.prototype.domainRecordDestroy = function(domain_id, record_id, callback) {
-	this.get('domains/' + domain_id + '/records/' + record_id + '/destroy', {}, function(error, body) {
+Digitalocean.prototype.domainRecordDestroy = function(id, recordId, callback) {
+	this.get('domains/' + id + '/records/' + recordId + '/destroy', {}, function(error, body) {
 		callback(error, body.status);
 	});
 };
 
 /**
 * Show event
-*	This method returns details of a event
-* @param  {[type]}   id       [description]
-* @param  {Function} callback [description]
+* This method is primarily used to report on the progress of an event by providing the percentage of completion.
+* @param {[Number]}     id              Required, this is the id of the event you would like more information about.
+* @param {Function}     callback        [description]
 */
-Digitalocean.prototype.eventGet = function(id,callback){
-	this.get('events/' + id ,{},function(error,body){
+Digitalocean.prototype.eventGet = function(id, callback){
+	this.get('events/' + id, {}, function(error,body){
 		callback(error,body.event);
 	});
 }

--- a/lib/digitalocean.js
+++ b/lib/digitalocean.js
@@ -473,7 +473,7 @@ Digitalocean.prototype.domainRecordGet = function(domain_id, record_id, callback
 
 /**
  * Edit Domain Record
- * This method creates a new domain name with an A record for the specified [ip_address].
+ * This method edits an existing domain record.
  * @param  {[Number, String]}   domain_id  Required, Integer or Domain Name (e.g. domain.com), specifies the domain to display.
  * @param  {[Number]}           record_id  Required, Integer, specifies the record to update.
  * @param  {[String]}           recordType Required, String, the type of record you would like to create. 'A', 'CNAME', 'NS', 'TXT', 'MX' or 'SRV'
@@ -484,9 +484,22 @@ Digitalocean.prototype.domainRecordGet = function(domain_id, record_id, callback
  * @param  {[Number]}           weight     Optional, Integer, Required for 'SRV' records
  * @param  {Function}           callback   [description]
  */
-Digitalocean.prototype.domainRecordNew = function(domain_id, record_id, recordType, data, name, priority, port, weight, callback) {
+Digitalocean.prototype.domainRecordEdit = function(domain_id, record_id, recordType, data, name, priority, port, weight, callback) {
 	this.get('domains/' + domain_id + '/records/' + record_id + '/edit', {record_type: recordType, data: data, name: name, priority: priority, port: port, weight: weight}, function(error, body) {
 		callback(error, body.domain_record);
+	});
+};
+
+/**
+ * Destroy Domain Record
+ * This method deletes the specified domain record.
+ * @param  {[Number, String]}   domain_id  Required, Integer or Domain Name (e.g. domain.com), specifies the domain for which to destroy a record.
+ * @param  {[Number]}           record_id  Required, Integer, specifies which record to destroy.
+ * @param  {Function}           callback   [description]
+ */
+Digitalocean.prototype.domainRecordDestroy = function(domain_id, record_id, callback) {
+	this.get('domains/' + domain_id + '/records/' + record_id + '/destroy', {}, function(error, body) {
+		callback(error, body.status);
 	});
 };
 

--- a/lib/digitalocean.js
+++ b/lib/digitalocean.js
@@ -285,6 +285,7 @@ Digitalocean.prototype.imageGet = function(id, callback) {
 		callback(error, body.image);
 	});
 };
+
 /**
  * Destroy Image
  * This method allows you to destroy an image. There is no way to restore a deleted image so be careful and ensure your data is properly backed up.
@@ -293,6 +294,19 @@ Digitalocean.prototype.imageGet = function(id, callback) {
  */
 Digitalocean.prototype.imageDestroy = function(id, callback) {
 	this.get('images/' + id + '/destroy/', {}, function(error, body) {
+		callback(error, body.event_id);
+	});
+};
+
+/**
+ * Transfer Image
+ * This method allows you to transfer an image to a specified region.
+ * @param  {[type]}   id       [description]
+ * @param  {[type]}   regionId [description]
+ * @param  {Function} callback [description]
+ */
+Digitalocean.prototype.imageTransfer = function(id, regionId, callback) {
+	this.get('images/' + id + '/transfer/', {region_id : regionId}, function(error, body) {
 		callback(error, body.event_id);
 	});
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "digitalocean-api",
-	"version": "0.0.4",
+	"version": "0.1.0",
 	"author": "Matej Simek <email@matejsimek.cz>",
 	"description": "DigitalOcean API wrapper",
 	"contributors": [ 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,12 @@
 	"version": "0.0.4",
 	"author": "Matej Simek <email@matejsimek.cz>",
 	"description": "DigitalOcean API wrapper",
+	"contributors": [ 
+	{
+		"name": "Ryan Sullivan",
+		"email": "ryan@toptiertech.com"
+	} 
+	],
 	"keywords": ["digitalocean", "digitalocean-api"],
 	"homepage": "https://github.com/enzy/digitalocean-api",
 

--- a/test/digitaloceanTest.js
+++ b/test/digitaloceanTest.js
@@ -12,29 +12,37 @@ describe('DigitalOcean API Wrapper', function() {
 		it('should get all droplets', function(done) {
 			api.dropletGetAll(done);
 		});
-
+		
 		it('should get all regions', function(done) {
 			api.regionGetAll(done);
 		});
-
+		
 		it('should get all images', function(done) {
+			api.images(null, done);
+		});
+		
+		it('should get all images again', function(done) {
 			api.imageGetAll(done);
 		});
-
+		
 		it('should get global images', function(done) {
 			api.imageGetGlobal(done);
 		});
-
+		
 		it('should get my images', function(done) {
 			api.imageGetMine(done);
 		});
-
+		
 		it('should get all sshKeys', function(done) {
 			api.sshKeyGetAll(done);
 		});
-
+		
 		it('should get all sizes', function(done) {
 			api.sizeGetAll(done);
+		});
+		
+		it('should get all domains', function(done) {
+			api.domainGetAll(done);
 		});
 	});
 });


### PR DESCRIPTION
I updated the library to use the latest Digital Ocean API.  Namely Domain support.  I went though the entire API and updated a few functions to comply with the latest API spec.

The only function that breaks compatibility is dropletNew.  They added privateNetworking and backupEnabled flags to the API specification.

I left them in there but I do not think the enable_backups and disable_backups are supported anymore.  I could be wrong but just something to look into. I don't know what the API looked like before now.

I also went though and flushed out the documentation for every function. I mainly just copied/pasted from the API page on the Digital Ocean site.

I noticed that some of the function names are different from the API calls.  I stuck with your naming convention for the functions I added but was wondering if the names you chose had lined up with the old API?  If they should be updated let me know and I can go ahead and do that.
