### PR TITLE
Edit the use ofextend() to work with xtend's latest version

### DIFF
--- a/lib/digitalocean.js
+++ b/lib/digitalocean.js
@@ -30,7 +30,7 @@ module.exports = Digitalocean;
  * @method get
  */
 Digitalocean.prototype._get = function(url, parameters, callback) {
-	extend(parameters, this.credentials); // Add credentials to parameters
+	parameters = extend(parameters, this.credentials); // Add credentials to parameters
 	var getURL = API_URL + '/' + url + '?' + querystring.stringify(parameters); // Construct URL with parameters
 
 	request.get({
@@ -78,7 +78,7 @@ Digitalocean.prototype.dropletNew = function(name, sizeId, imageId, regionId, op
 		image_id: imageId,
 		region_id: regionId
 	};
-	extend(options, optionals);
+	options = extend(options, optionals);
 
 	this._get('droplets/new', options, function(error, body) {
 		callback(error, body.droplet);
@@ -567,7 +567,7 @@ Digitalocean.prototype.domainRecordNew = function(id, recordType, data, optional
 		record_type: recordType,
 		data: data
 	};
-	extend(options, optionals);
+	options = extend(options, optionals);
 
 	this._get('domains/' + id + '/records/new', options, function(error, body) {
 		callback(error, body.domain_record);
@@ -606,7 +606,7 @@ Digitalocean.prototype.domainRecordEdit = function(id, recordId, recordType, dat
 		record_type: recordType,
 		data: data
 	};
-	extend(options, optionals);
+	options = extend(options, optionals);
 
 	this._get('domains/' + id + '/records/' + recordId + '/edit', options, function(error, body) {
 		callback(error, body.domain_record);


### PR DESCRIPTION
xtend version 1.0.3 used to edit the object in place (make the first arg contain all of the properties), but with version 2.x, xtend creates and returns a new object that has all of the properties. So instead of just calling `extend()`, its return value needs to be reassigned to the first argument (`parameters` and `options`) in `digitialocean.js`.
